### PR TITLE
Actualizar android/app/build.gradle, límite de 64K.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,6 +42,7 @@ android {
         applicationId "com.example.qrreaderapp"
         minSdkVersion 21
         targetSdkVersion 28
+        multiDexEnabled true
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Habilitar multidex para evitar el límite de 64 K, que causa error al ejecutar 'Hot Reload' después de agregar los paquetes 'path_provider' y/o 'sqflite'. Info: https://developer.android.com/studio/build/multidex#about